### PR TITLE
Fix spelling mistake in "withConnection" template

### DIFF
--- a/examples/pool_borrow_callback.nim
+++ b/examples/pool_borrow_callback.nim
@@ -16,5 +16,5 @@ proc onBorrow(conn: RedisConn, lastReturned: float) =
 
 let pool = newRedisPool(2, onBorrow = onBorrow)
 
-pool.withConnnection conn:
+pool.withConnection conn:
   echo "Borrowed ", conn

--- a/src/ready/pools.nim
+++ b/src/ready/pools.nim
@@ -90,7 +90,7 @@ proc borrow*(pool: RedisPool): RedisConn {.gcsafe.} =
       if pool.onBorrow != nil:
         pool.onBorrow(result, epochTime())
 
-template withConnnection*(pool: RedisPool, conn, body) =
+template withConnection*(pool: RedisPool, conn, body) =
   block:
     let conn = pool.borrow()
     try:
@@ -105,5 +105,5 @@ proc command*(
 ): RedisReply =
   ## Borrows a Redis connection from the pool, sends a command to the
   ## server and receives the reply.
-  pool.withConnnection conn:
+  pool.withConnection conn:
     result = conn.command(command, args)

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -43,7 +43,7 @@ block:
     discard conn.command("PING")
 
   let pool = newRedisPool(1, onConnect = onConnect, onBorrow = onBorrow)
-  pool.withConnnection redis:
+  pool.withConnection redis:
     discard redis.command("SET", "mynumber", "0")
     redis.send("INCR", "mynumber")
     redis.send("INCR", "mynumber")


### PR DESCRIPTION
While trying to use this template I noticed it was actually spelled "withConnnection" (with 3 "n" instead of 2). Renaming to avoid confusion.